### PR TITLE
Fix: unique data and multiple positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [1.1.1] - 11-02-2025
+
+Fixes:
+-   Only one position was set/removed in the create/update script.
+-   Resource data was not unique, resulting in unnecessary API calls.
+-   The DepartmentManager resource script’s success flag was not set to false when actions failed in the foreach loop.
+
+## [1.1.0] - 04-10-2024
+
+Fixes after first implementation. Feature: removed enable/disable script
+
 ## [1.0.0] - 04-07-2024
 
 This is the first official release of _HelloID-Conn-Prov-Target-CAPP12_. This release is based on template version _1.2.0_, with some features from the next release, 1.3?.x. The main feature added from the upcoming release is the integration of the Dryrun message into the main processing flow. Basically, the Dryrun switch has been moved as close as possible to the actual web requests.

--- a/create.ps1
+++ b/create.ps1
@@ -37,7 +37,8 @@ function Get-Capp12AuthorizationTokenAndCreateHeaders {
         $headers.Add('Accept', 'application/json')
         $headers.Add('Content-Type', 'application/json')
         Write-Output $headers
-    } catch {
+    }
+    catch {
         $PSCmdlet.ThrowTerminatingError($_)
     }
 }
@@ -58,7 +59,8 @@ function Resolve-CAPP12Error {
         }
         if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
             $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
-        } elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
             if ($null -ne $ErrorObject.Exception.Response) {
                 $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
                 if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
@@ -69,7 +71,8 @@ function Resolve-CAPP12Error {
         try {
             $errorDetailsObject = ($httpErrorObj.ErrorDetails | ConvertFrom-Json)
             $httpErrorObj.FriendlyMessage = $errorDetailsObject.error
-        } catch {
+        }
+        catch {
             $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
         }
         Write-Output $httpErrorObj
@@ -157,8 +160,8 @@ try {
                                 Message = "Successfully set active CAPP12 assignment: [$($position)]"
                                 IsError = $false
                             })
-                        break
                     }
+                    break
                 }
                 'SetDepartments' {
                     foreach ($department in $desiredDepartments) {
@@ -186,14 +189,16 @@ try {
                     break
                 }
             }
-        } catch {
+        }
+        catch {
             $ex = $PSItem
             if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
                 $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
                 $errorObj = Resolve-CAPP12Error -ErrorObject $ex
                 $auditMessage = "Could not create or set positions or department CAPP12 account. Error: $($errorObj.FriendlyMessage)"
                 Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
-            } else {
+            }
+            else {
                 $auditMessage = "Could not create or set positions or department CAPP12 account. Error: $($ex.Exception.Message)"
                 Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
             }
@@ -206,7 +211,8 @@ try {
     if ( -not ($outputContext.AuditLogs.IsError -contains $true)) {
         $outputContext.Success = $true
     }
-} catch {
+}
+catch {
     $outputContext.success = $false
     $ex = $PSItem
     if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
@@ -214,7 +220,8 @@ try {
         $errorObj = Resolve-CAPP12Error -ErrorObject $ex
         $auditMessage = "Could not create or correlate CAPP12 account. Error: $($errorObj.FriendlyMessage)"
         Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
-    } else {
+    }
+    else {
         $auditMessage = "Could not create or correlate CAPP12 account. Error: $($ex.Exception.Message)"
         Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
     }

--- a/delete.ps1
+++ b/delete.ps1
@@ -33,7 +33,8 @@ function Get-Capp12AuthorizationTokenAndCreateHeaders {
         $headers.Add('Accept', 'application/json')
         $headers.Add('Content-Type', 'application/json')
         Write-Output $headers
-    } catch {
+    }
+    catch {
         $PSCmdlet.ThrowTerminatingError($_)
     }
 }
@@ -54,7 +55,8 @@ function Resolve-CAPP12Error {
         }
         if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
             $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
-        } elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
             if ($null -ne $ErrorObject.Exception.Response) {
                 $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
                 if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
@@ -65,7 +67,8 @@ function Resolve-CAPP12Error {
         try {
             $errorDetailsObject = ($httpErrorObj.ErrorDetails | ConvertFrom-Json)
             $httpErrorObj.FriendlyMessage = $errorDetailsObject.error
-        } catch {
+        }
+        catch {
             $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
         }
         Write-Output $httpErrorObj
@@ -96,7 +99,8 @@ try {
     if ($null -ne $correlatedAccount) {
         $correlatedAccount.code = $actionContext.References.Account
         $action = 'DisableAccount'
-    } else {
+    }
+    else {
         $action = 'NotFound'
     }
 
@@ -141,7 +145,8 @@ try {
             break
         }
     }
-} catch {
+}
+catch {
     $outputContext.success = $false
     $ex = $PSItem
     if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
@@ -149,7 +154,8 @@ try {
         $errorObj = Resolve-CAPP12Error -ErrorObject $ex
         $auditMessage = "Could not disable CAPP12 account. Error: $($errorObj.FriendlyMessage)"
         Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
-    } else {
+    }
+    else {
         $auditMessage = "Could not disable CAPP12 account. Error: $($_.Exception.Message)"
         Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
     }

--- a/resources/Departments/resources.ps1
+++ b/resources/Departments/resources.ps1
@@ -33,7 +33,8 @@ function Get-Capp12AuthorizationTokenAndCreateHeaders {
         $headers.Add('Accept', 'application/json')
         $headers.Add('Content-Type', 'application/json')
         Write-Output $headers
-    } catch {
+    }
+    catch {
         $PSCmdlet.ThrowTerminatingError($_)
     }
 }
@@ -54,7 +55,8 @@ function Resolve-CAPP12Error {
         }
         if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
             $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
-        } elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
             if ($null -ne $ErrorObject.Exception.Response) {
                 $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
                 if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
@@ -65,7 +67,8 @@ function Resolve-CAPP12Error {
         try {
             $errorDetailsObject = ($httpErrorObj.ErrorDetails | ConvertFrom-Json)
             $httpErrorObj.FriendlyMessage = $errorDetailsObject.error
-        } catch {
+        }
+        catch {
             $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
         }
         Write-Output $httpErrorObj
@@ -74,12 +77,17 @@ function Resolve-CAPP12Error {
 #endregion
 
 try {
-    Write-Information "Creating [$($resourceContext.SourceData.Count)] Departments"
+    Write-Information "Creating [$($resourceContext.SourceData.Count)] Departments (before filtering)"
+    
+    # Only process unique results
+    $resourceData = $resourceContext.SourceData | Select-Object -Unique externalId, displayName
+    
+    Write-Information "Creating [$($resourceData.Count)] Departments"
     $outputContext.Success = $true
 
     $headers = Get-Capp12AuthorizationTokenAndCreateHeaders
 
-    foreach ($resource in $resourceContext.SourceData) {
+    foreach ($resource in $resourceData) {
         try {
             <# Resource creation preview uses a timeout of 30 seconds while actual run has timeout of 10 minutes #>
             if ([string]::IsNullOrEmpty($resource.externalId) -or [string]::IsNullOrEmpty($resource.displayName)) {
@@ -90,9 +98,10 @@ try {
                 code  = $resource.externalId
                 title = $resource.displayName
             }
-            if ($actionContext.DryRun -eq $True) {
+            if ($actionContext.DryRun -eq $true) {
                 Write-Information "[DryRun] Create [$($body.Code) | $($body.title) ] CAPP12 Department, will be executed during enforcement"
-            } else {
+            }
+            else {
                 $splatDepartments = @{
                     Uri     = "$($actionContext.Configuration.BaseUrl)/api/v1/departments"
                     Headers = $headers
@@ -108,7 +117,8 @@ try {
                 #         IsError = $false
                 #     })
             }
-        } catch {
+        }
+        catch {
             $outputContext.Success = $false
             $ex = $PSItem
             if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
@@ -116,7 +126,8 @@ try {
                 $errorObj = Resolve-CAPP12Error -ErrorObject $ex
                 $auditMessage = "Could not create CAPP12 Department. Error: $($errorObj.FriendlyMessage)"
                 Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
-            } else {
+            }
+            else {
                 $auditMessage = "Could not create CAPP12 Department. Error: $($ex.Exception.Message)"
                 Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
             }
@@ -126,7 +137,8 @@ try {
                 })
         }
     }
-} catch {
+}
+catch {
     $outputContext.Success = $false
     $ex = $PSItem
     if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
@@ -134,7 +146,8 @@ try {
         $errorObj = Resolve-CAPP12Error -ErrorObject $ex
         $auditMessage = "Could not create CAPP12 Departments. Error: $($errorObj.FriendlyMessage)"
         Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
-    } else {
+    }
+    else {
         $auditMessage = "Could not create CAPP12 Departments. Error: $($ex.Exception.Message)"
         Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
     }

--- a/update.ps1
+++ b/update.ps1
@@ -35,7 +35,8 @@ function Get-Capp12AuthorizationTokenAndCreateHeaders {
         $headers.Add('Accept', 'application/json')
         $headers.Add('Content-Type', 'application/json')
         Write-Output $headers
-    } catch {
+    }
+    catch {
         $PSCmdlet.ThrowTerminatingError($_)
     }
 }
@@ -56,7 +57,8 @@ function Resolve-CAPP12Error {
         }
         if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
             $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
-        } elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
             if ($null -ne $ErrorObject.Exception.Response) {
                 $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
                 if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
@@ -67,7 +69,8 @@ function Resolve-CAPP12Error {
         try {
             $errorDetailsObject = ($httpErrorObj.ErrorDetails | ConvertFrom-Json)
             $httpErrorObj.FriendlyMessage = $errorDetailsObject.error
-        } catch {
+        }
+        catch {
             $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
         }
         Write-Output $httpErrorObj
@@ -87,9 +90,11 @@ function Compare-Array {
     )
     if ($null -eq $DifferenceObject) {
         $Left = $ReferenceObject
-    } elseif ($null -eq $ReferenceObject) {
+    }
+    elseif ($null -eq $ReferenceObject) {
         $right = $DifferenceObject
-    } else {
+    }
+    else {
         $left = [string[]][Linq.Enumerable]::Except($ReferenceObject, $DifferenceObject)
         $right = [string[]][Linq.Enumerable]::Except($DifferenceObject, $ReferenceObject)
         $common = [string[]][Linq.Enumerable]::Intersect($ReferenceObject, $DifferenceObject)
@@ -157,7 +162,8 @@ try {
         $propertiesChanged = Compare-Object @splatCompareProperties -PassThru | Where-Object { $_.SideIndicator -eq '=>' }
         if ($propertiesChanged) {
             $actionList += 'UpdateAccount'
-        } else {
+        }
+        else {
             $actionList += 'NoChanges'
         }
         $revokeDepartments , $grantDepartments , $update = Compare-Array -ReferenceObject $outputContext.PreviousData._extension.Departments -DifferenceObject $outputContext.Data._extension.Departments
@@ -174,7 +180,8 @@ try {
         if ($revokePositions.count -gt 0) {
             $actionList += 'RevokePositions'
         }
-    } else {
+    }
+    else {
         $action = 'NotFound'
     }
 
@@ -229,8 +236,8 @@ try {
                                 Message = "Successfully added CAPP12 assignment: [$($position)]"
                                 IsError = $false
                             })
-                        break
                     }
+                    break
                 }
                 'RevokePositions' {
                     foreach ($position in $revokePositions) {
@@ -253,8 +260,8 @@ try {
                                 Message = "Successfully revoked CAPP12 assignment: [$($position)]"
                                 IsError = $false
                             })
-                        break
                     }
+                    break
                 }
                 'AddDepartments' {
                     foreach ($department in $grantDepartments) {
@@ -323,14 +330,16 @@ try {
                     break
                 }
             }
-        } catch {
+        }
+        catch {
             $ex = $PSItem
             if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
                 $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
                 $errorObj = Resolve-CAPP12Error -ErrorObject $ex
                 $auditMessage = "Could not update or set positions or department CAPP12 account. Error: $($errorObj.FriendlyMessage)"
                 Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
-            } else {
+            }
+            else {
                 $auditMessage = "Could not update or set positions or department CAPP12 account. Error: $($ex.Exception.Message)"
                 Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
             }
@@ -343,7 +352,8 @@ try {
     if ( -not ($outputContext.AuditLogs.IsError -contains $true)) {
         $outputContext.Success = $true
     }
-} catch {
+}
+catch {
     $outputContext.Success = $false
     $ex = $PSItem
     if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
@@ -351,7 +361,8 @@ try {
         $errorObj = Resolve-CAPP12Error -ErrorObject $ex
         $auditMessage = "Could not update CAPP12 account. Error: $($errorObj.FriendlyMessage)"
         Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
-    } else {
+    }
+    else {
         $auditMessage = "Could not update CAPP12 account. Error: $($ex.Exception.Message)"
         Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
     }


### PR DESCRIPTION
Fixes:
-   Only one position was set/removed in the create/update script.
-   Resource data was not unique, resulting in unnecessary API calls.
-   The DepartmentManager resource script’s success flag was not set to false when actions failed in the foreach loop.